### PR TITLE
feat: add destination playlist fields to PlaylistMigration for cron job automation

### DIFF
--- a/prisma/migrations/20250812175243_add_destination_playlist_name_and_id_in_schema/migration.sql
+++ b/prisma/migrations/20250812175243_add_destination_playlist_name_and_id_in_schema/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "PlaylistMigration" ADD COLUMN     "destinationPlaylistId" TEXT,
+ADD COLUMN     "destinationPlaylistName" TEXT;
+
+-- AlterTable
+ALTER TABLE "sessions" ALTER COLUMN "expires_at" SET DEFAULT NOW() + INTERVAL '1 day';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,26 +93,30 @@ model YouTubeData {
 }
 
 model PlaylistMigration {
-  id                  String   @id @default(cuid())
-  userId              String
-  playlistId          String
-  sourcePlatform      String
+  id String @id @default(cuid())
+  userId String
+  playlistId String
+  sourcePlatform String
   destinationPlatform String
-  sourceTrackIds      String[]
-  migrationCounter    Int
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  sourceTrackIds String[]
+  migrationCounter Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // 🆕 Store destination playlist details
+  destinationPlaylistId String?
+  destinationPlaylistName String?
 
   // 🔄 Sync Job Config
-  autoSyncEnabled     Boolean   @default(false)
+  autoSyncEnabled Boolean @default(false)
   syncIntervalMinutes Int?
-  nextSyncAt          DateTime?
-  lastSyncAt          DateTime?
-  lastSyncStatus      String?
-  lastSyncError       String?
+  nextSyncAt DateTime?
+  lastSyncAt DateTime?
+  lastSyncStatus String?
+  lastSyncError String?
 
   // Relation to User
-  user                User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
   @@unique([userId, playlistId, sourcePlatform, destinationPlatform])
 }
+


### PR DESCRIPTION
1. Enables Autonomous Cron Jobs: Added destinationPlaylistId and destinationPlaylistName fields to store playlist metadata during manual migrations, allowing automated sync jobs to access playlist names without requiring user input or additional API calls.

2. Maintains Backward Compatibility: Both new fields are optional (String?) ensuring existing migration records continue to work without breaking changes while gradually populating destination info for future automations.

3. Optimizes Cross-Platform Performance: Stores both playlist ID (for direct API access) and name (for fallback/creation) to handle different platform requirements efficiently - Spotify uses names for creation while YouTube needs IDs for updates.