### PR TITLE
ci: enforce Prettier formatting on PRs via GitHub Actions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Prettier — check formatting
+        run: npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+src/generated
+prisma/migrations
+*.json
+*.md
+dump.rdb

--- a/.prettierrc 
+++ b/.prettierrc 
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "serve": "node -r dotenv/config dist/backend/server.js",
     "generate:openapi": "ts-node scripts/generateDocs.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "it": "npm run build && npm run serve"
+    "it": "npm run build && npm run serve",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\""
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"
@@ -29,6 +31,7 @@
     "concurrently": "^8.2.2",
     "esbuild": "^0.25.0",
     "nodemon": "^3.1.4",
+    "prettier": "^3.8.3",
     "prisma": "^7.6.0",
     "ts-jest": "^29.4.0",
     "ts-node-dev": "^2.0.0",


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that runs a Prettier format check on every PR targeting main.

Changes:
- `.github/workflows/format.yaml` — CI workflow that runs `npm run format:check` on every PR
- `.prettierrc` — industry-standard Prettier config (single quotes, trailing commas, 100 print width)
- `.prettierignore` — excludes `dist/`, `src/generated/`, `prisma/migrations/`, JSON, and Markdown files
- `package.json` — adds `format` and `format:check` scripts