### PR TITLE
fix: resolve npm ci peer dependency conflict and add Prettier config

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
       - name: Prettier — check formatting
         run: npm run format:check
+        

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "concurrently": "^8.2.2",
         "esbuild": "^0.25.0",
         "nodemon": "^3.1.4",
+        "prettier": "^3.8.3",
         "prisma": "^7.6.0",
         "ts-jest": "^29.4.0",
         "ts-node-dev": "^2.0.0",
@@ -8067,6 +8068,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {


### PR DESCRIPTION
Fixes the CI failure from PR #36.

- `npm ci --legacy-peer-deps` — resolves the esbuild/dotenv-run peer dependency conflict that was breaking the install step
- `.prettierrc` — adds the Prettier config that was missing from the initial commit